### PR TITLE
Some fixes and additions to QuantumStorage

### DIFF
--- a/Common/Configs/ServerConfig.cs
+++ b/Common/Configs/ServerConfig.cs
@@ -52,7 +52,7 @@ namespace YAQOLM.Common.Configs {
         [Label("$Mods.YAQOLM.Config.QuantumStrongbox")]
         [Tooltip("Combines all 4 player inventories into one item")]
         [ReloadRequired]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool QuantumStrongbox { get; set; }
 
         [Label("$Mods.YAQOLM.Config.GoldenHorseshoeBalloon")]

--- a/Common/Players/KeybindPlayer.cs
+++ b/Common/Players/KeybindPlayer.cs
@@ -37,12 +37,10 @@ namespace YAQOLM.Common.Players {
             }
         }
 
-        public override void UpdateAutopause()
-        {
-          	if (Main.playerInventory || Main.npcChatText != "" || Main.player[Main.myPlayer].sign >= 0 || Main.ingameOptionsWindow || Main.inFancyUI)
-          	{
-            		ProcessTriggers(null);
-          	}
+        public override void UpdateAutopause() {
+            if (Main.playerInventory || Main.npcChatText != "" || Main.player[Main.myPlayer].sign >= 0 || Main.ingameOptionsWindow || Main.inFancyUI) {
+                ProcessTriggers(null);
+            }
         }
 
         private void QuickSwitchAndUse(int itemType, int extraData = -1) {

--- a/Common/Players/KeybindPlayer.cs
+++ b/Common/Players/KeybindPlayer.cs
@@ -37,6 +37,14 @@ namespace YAQOLM.Common.Players {
             }
         }
 
+        public override void UpdateAutopause()
+        {
+          	if (Main.playerInventory || Main.npcChatText != "" || Main.player[Main.myPlayer].sign >= 0 || Main.ingameOptionsWindow || Main.inFancyUI)
+          	{
+            		ProcessTriggers(null);
+          	}
+        }
+
         private void QuickSwitchAndUse(int itemType, int extraData = -1) {
             // Guard clause
             if (Player.itemTime != 0 || Player.itemAnimation != 0)
@@ -56,6 +64,12 @@ namespace YAQOLM.Common.Players {
                 return;
             }
 
+            if (itemType == ModContent.ItemType<QuantumStrongbox>()) {
+                var modItem = Player.inventory[index].ModItem as QuantumStrongbox;
+                modItem.SetAndResetMode(extraData);
+                return;
+            }
+
             // Use our item at that index
             originalSelectedItem = Player.selectedItem;
             autoRevertSelectedItem = true;
@@ -65,10 +79,6 @@ namespace YAQOLM.Common.Players {
             if (extraData != -1) {
                 if (itemType == ModContent.ItemType<SpiralMirror>()) {
                     var modItem = Player.inventory[index].ModItem as SpiralMirror;
-                    modItem.SetAndResetMode(extraData);
-                }
-                else if (itemType == ModContent.ItemType<QuantumStrongbox>()) {
-                    var modItem = Player.inventory[index].ModItem as QuantumStrongbox;
                     modItem.SetAndResetMode(extraData);
                 }
             }

--- a/Content/Items/QuantumStrongbox.cs
+++ b/Content/Items/QuantumStrongbox.cs
@@ -2,13 +2,13 @@ using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria;
-using Terraria.UI;
-using Terraria.UI.Gamepad;
-using Terraria.GameInput;
 using Terraria.Audio;
 using Terraria.GameContent.Creative;
+using Terraria.GameInput;
 using Terraria.ID;
 using Terraria.ModLoader;
+using Terraria.UI;
+using Terraria.UI.Gamepad;
 using YAQOLM.Common.Configs;
 
 namespace YAQOLM.Content.Items {
@@ -54,7 +54,7 @@ namespace YAQOLM.Content.Items {
             resetMode = mode;
             mode = newMode;
             var player = Main.LocalPlayer;
-        		ToggleChest(ref player, mode);
+            ToggleChest(ref player, mode);
         }
 
         public override bool CanRightClick() => true;
@@ -90,8 +90,8 @@ namespace YAQOLM.Content.Items {
             tooltips.Insert(index + 1, new(Mod, "Tooltip2", "Right click to switch mode"));
 
             if (PlayerInput.Triggers.JustPressed.MouseMiddle) {
-              var player = Main.LocalPlayer;
-              ToggleChest(ref player, mode);
+                var player = Main.LocalPlayer;
+                ToggleChest(ref player, mode);
             }
 
         }
@@ -114,41 +114,37 @@ namespace YAQOLM.Content.Items {
             player.itemLocation += new Vector2(-6f * player.direction, 2f);
         }
 
-        private void ToggleChest(ref Player player, int mode)
-        {
+        private void ToggleChest(ref Player player, int mode) {
             int chestId = -1;
             SoundStyle? sound = null;
             switch (mode) {
-	            case 0:
-  	         		sound = SoundID.Item59;
-             		chestId = -2;
-                break;
-              case 1:
-            		sound = SoundID.Item149;
-             		chestId = -3;
-                break;
-              case 2:
-             		sound = SoundID.Item117;
-             		chestId = -4;
-                break;
-              case 3:
-             		sound = SoundID.Item130;
-             		chestId = -5;
-                break;
+                case 0:
+                    sound = SoundID.Item59;
+                    chestId = -2;
+                    break;
+                case 1:
+                    sound = SoundID.Item149;
+                    chestId = -3;
+                    break;
+                case 2:
+                    sound = SoundID.Item117;
+                    chestId = -4;
+                    break;
+                case 3:
+                    sound = SoundID.Item130;
+                    chestId = -5;
+                    break;
             }
 
-            if (player.chest == chestId)
-            {
+            if (player.chest == chestId) {
                 player.chest = -1;
                 SoundEngine.PlaySound(sound ?? SoundID.MenuClose);
             }
-            else
-            {
+            else {
                 var x = player.Center.ToTileCoordinates().X;
                 var y = player.Center.ToTileCoordinates().Y;
                 player.chest = chestId;
-                for (int i = 0; i < 40; i++)
-                {
+                for (int i = 0; i < 40; i++) {
                     ItemSlot.SetGlow(i, -1f, chest: true);
                 }
 

--- a/description_workshop.txt
+++ b/description_workshop.txt
@@ -78,9 +78,6 @@ Don't like something I've changed? That's fine, you can disable every single fea
 [*]Gemstone Magnet: A Treasure Magnet upgrade that works while in your inventory - 1 Treasure Magnet, 3 Sapphires, 3 Rubies, 3 Emeralds @ Crystal Ball
 [*]Magnificent Magnet: A Gemstone Magnet upgrade that lets you pull all items to you - 1 Gemstone Magnet, 3 of each Mech Boss Soul @ Hardmode Anvil
 [*]Quantum Strongbox: A combination of each player inventory, right click to change mode - 1 of each player inventory accessor, 3 of each Mech Soul @ Hardmode Anvil
-[list]
-[*]Using this item will spam the opening chest sound that I cannot fix, use at your own discretion
-[/list]
 [*]Golden Horseshoe Balloon: A horseshoe balloon that is crafted from and into every other horseshoe balloon
 [*]Prefix Hammers: Consumables that apply a given prefix to your held weapon - 1 of each Lunar Fragment @ Ancient Manipulator
 [*]Flower of the Jungle: Summons Plantera - 5 Jungle Spores, 3 Chlorophyte Bars @ Hardmode Anvil


### PR DESCRIPTION
*Keybinds work in autopause
*Fixed QuantumStorage always opened PiggyBank
*Fixed Player's inventory freeze if QuantumStorage was opened with Autopause enabled
*MiddleMouse click on QuanumStorage in Player's inventory opens selected storage